### PR TITLE
refactor module, fix types and add JsDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # WebUI Deno v2.3.0
 
-[![Website](https://img.shields.io/circleci/project/github/badges/shields/master?style=for-the-badge)](https://github.com/webui-dev/deno-webui) [![Website](https://img.shields.io/github/issues/webui-dev/deno-webui.svg?branch=master&style=for-the-badge&url=https://google.com)](https://github.com/webui-dev/deno-webui/issues) [![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://google.com)](https://webui.me/)
+[![Website](https://img.shields.io/circleci/project/github/badges/shields/master?style=for-the-badge)](https://github.com/webui-dev/deno-webui)
+[![Website](https://img.shields.io/github/issues/webui-dev/deno-webui.svg?branch=master&style=for-the-badge&url=https://google.com)](https://github.com/webui-dev/deno-webui/issues)
+[![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://google.com)](https://webui.me/)
 
-> Use any web browser as GUI, with Deno in the backend and HTML5 in the frontend, all in a lightweight Deno module.
+> Use any web browser as GUI, with Deno in the backend and HTML5 in the
+> frontend, all in a lightweight Deno module.
 
 ![ScreenShot](screenshot.png)
 
 ## Features
 
-- Fully Independent (*No need for any third-party runtimes*)
-- Lightweight *~900 Kb* for the whole package & Small memory footprint
-- Fast binary communication protocol between WebUI and the browser (*Instead of JSON*)
+- Fully Independent (_No need for any third-party runtimes_)
+- Lightweight _~900 Kb_ for the whole package & Small memory footprint
+- Fast binary communication protocol between WebUI and the browser (_Instead of
+  JSON_)
 - Multi-platform & Multi-Browser
 - Using private profile for safety
 - Original library written in Pure C
 
 ## Screenshot
 
-This [text editor example](https://github.com/webui-dev/deno-webui/tree/main/examples) is written in Deno using WebUI as the GUI library.
+This
+[text editor example](https://github.com/webui-dev/deno-webui/tree/main/examples)
+is written in Deno using WebUI as the GUI library.
 
 ![ScreenShot](webui_deno_example.png)
 
@@ -39,11 +45,13 @@ await webui.wait();
 
 ## Documentation
 
- - [Online Documentation](https://webui.me/docs/#/deno_api)
+- [Online Documentation](https://webui.me/docs/#/deno_api)
 
 ## CppCon 2019 Presentation
 
-[Borislav Stanimirov](https://ibob.bg/) explained at [C++ Conference 2019 (*YouTube*)](https://www.youtube.com/watch?v=bbbcZd4cuxg) how beneficial it is to use the web browser as GUI.
+[Borislav Stanimirov](https://ibob.bg/) explained at
+[C++ Conference 2019 (_YouTube_)](https://www.youtube.com/watch?v=bbbcZd4cuxg)
+how beneficial it is to use the web browser as GUI.
 
 <!-- <div align="center">
   <a href="https://www.youtube.com/watch?v=bbbcZd4cuxg"><img src="https://img.youtube.com/vi/bbbcZd4cuxg/0.jpg" alt="Embrace Modern Technology: Using HTML 5 for GUI in C++ - Borislav Stanimirov - CppCon 2019"></a>
@@ -53,73 +61,90 @@ await webui.wait();
 
 ## UI & The Web Technologies
 
-Web application UI design is not just about how a product looks but how it works. Using web technologies in your UI makes your product modern and professional, And a well-designed web application will help you make a solid first impression on potential customers. Great web application design also assists you in nurturing leads and increasing conversions. In addition, it makes navigating and using your web app easier for your users.
+Web application UI design is not just about how a product looks but how it
+works. Using web technologies in your UI makes your product modern and
+professional, And a well-designed web application will help you make a solid
+first impression on potential customers. Great web application design also
+assists you in nurturing leads and increasing conversions. In addition, it makes
+navigating and using your web app easier for your users.
 
 ## Why Use Web Browser?
 
-Today's web browsers have everything a modern UI needs. Web browsers are very sophisticated and optimized. Therefore, using it as a GUI will be an excellent choice. While old legacy GUI lib is complex and outdated, a WebView-based app is still an option. However, a WebView needs a huge SDK to build and many dependencies to run, and it can only provide some features like a real web browser. That is why WebUI uses real web browsers to give you full features of comprehensive web technologies while keeping your software lightweight and portable.
+Today's web browsers have everything a modern UI needs. Web browsers are very
+sophisticated and optimized. Therefore, using it as a GUI will be an excellent
+choice. While old legacy GUI lib is complex and outdated, a WebView-based app is
+still an option. However, a WebView needs a huge SDK to build and many
+dependencies to run, and it can only provide some features like a real web
+browser. That is why WebUI uses real web browsers to give you full features of
+comprehensive web technologies while keeping your software lightweight and
+portable.
 
 ## How does it work?
 
 ![ScreenShot](webui_diagram.png)
 
-Think of WebUI like a WebView controller, but instead of embedding the WebView controller in your program, which makes the final program big in size, and non-portable as it needs the WebView runtimes. Instead, by using WebUI, you use a tiny static/dynamic library to run any installed web browser and use it as GUI, which makes your program small, fast, and portable. **All it needs is a web browser**.
+Think of WebUI like a WebView controller, but instead of embedding the WebView
+controller in your program, which makes the final program big in size, and
+non-portable as it needs the WebView runtimes. Instead, by using WebUI, you use
+a tiny static/dynamic library to run any installed web browser and use it as
+GUI, which makes your program small, fast, and portable. **All it needs is a web
+browser**.
 
 ## Runtime Dependencies Comparison
 
-|  | WebView | Qt | WebUI |
-| ------ | ------ | ------ | ------ |
-| Runtime Dependencies on Windows | *WebView2* | *QtCore, QtGui, QtWidgets* | ***A Web Browser*** |
-| Runtime Dependencies on Linux | *GTK3, WebKitGTK* | *QtCore, QtGui, QtWidgets* | ***A Web Browser*** |
-| Runtime Dependencies on macOS | *Cocoa, WebKit* | *QtCore, QtGui, QtWidgets* | ***A Web Browser*** |
+|                                 | WebView           | Qt                         | WebUI               |
+| ------------------------------- | ----------------- | -------------------------- | ------------------- |
+| Runtime Dependencies on Windows | _WebView2_        | _QtCore, QtGui, QtWidgets_ | _**A Web Browser**_ |
+| Runtime Dependencies on Linux   | _GTK3, WebKitGTK_ | _QtCore, QtGui, QtWidgets_ | _**A Web Browser**_ |
+| Runtime Dependencies on macOS   | _Cocoa, WebKit_   | _QtCore, QtGui, QtWidgets_ | _**A Web Browser**_ |
 
 ## Supported Web Browsers
 
-| OS | Browser | Status |
-| ------ | ------ | ------ |
-| Windows | Mozilla Firefox | ✔️ |
-| Windows | Google Chrome | ✔️ |
-| Windows | Microsoft Edge | ✔️ |
-| Windows | Chromium | ✔️ |
-| Windows | Yandex | ✔️ |
-| Windows | Brave | ✔️ |
-| Windows | Vivaldi | ✔️ |
-| Windows | Epic | ✔️ |
-| Windows | Opera | *coming soon* |
-| - | - | - |
-| Linux | Mozilla Firefox | ✔️ |
-| Linux | Google Chrome | ✔️ |
-| Linux | Microsoft Edge | ✔️ |
-| Linux | Chromium | ✔️ |
-| Linux | Yandex | ✔️ |
-| Linux | Brave | ✔️ |
-| Linux | Vivaldi | ✔️ |
-| Linux | Epic | *Does Not Exist* |
-| Linux | Opera | *coming soon* |
-| - | - | - |
-| macOS | Mozilla Firefox | ✔️ |
-| macOS | Google Chrome | ✔️ |
-| macOS | Microsoft Edge | ✔️ |
-| macOS | Chromium | ✔️ |
-| macOS | Yandex | ✔️ |
-| macOS | Brave | ✔️ |
-| macOS | Vivaldi | ✔️ |
-| macOS | Epic | ✔️ |
-| macOS | Apple Safari | *coming soon* |
-| macOS | Opera | *coming soon* |
+| OS      | Browser         | Status           |
+| ------- | --------------- | ---------------- |
+| Windows | Mozilla Firefox | ✔️                |
+| Windows | Google Chrome   | ✔️                |
+| Windows | Microsoft Edge  | ✔️                |
+| Windows | Chromium        | ✔️                |
+| Windows | Yandex          | ✔️                |
+| Windows | Brave           | ✔️                |
+| Windows | Vivaldi         | ✔️                |
+| Windows | Epic            | ✔️                |
+| Windows | Opera           | _coming soon_    |
+| -       | -               | -                |
+| Linux   | Mozilla Firefox | ✔️                |
+| Linux   | Google Chrome   | ✔️                |
+| Linux   | Microsoft Edge  | ✔️                |
+| Linux   | Chromium        | ✔️                |
+| Linux   | Yandex          | ✔️                |
+| Linux   | Brave           | ✔️                |
+| Linux   | Vivaldi         | ✔️                |
+| Linux   | Epic            | _Does Not Exist_ |
+| Linux   | Opera           | _coming soon_    |
+| -       | -               | -                |
+| macOS   | Mozilla Firefox | ✔️                |
+| macOS   | Google Chrome   | ✔️                |
+| macOS   | Microsoft Edge  | ✔️                |
+| macOS   | Chromium        | ✔️                |
+| macOS   | Yandex          | ✔️                |
+| macOS   | Brave           | ✔️                |
+| macOS   | Vivaldi         | ✔️                |
+| macOS   | Epic            | ✔️                |
+| macOS   | Apple Safari    | _coming soon_    |
+| macOS   | Opera           | _coming soon_    |
 
 ## Supported Languages
 
-| Language | Status | Link |
-| ------ | ------ | ------ |
-| C/C++ | ✔️ | [WebUI](https://github.com/webui-dev/webui) |
-| Python | ✔️ | [Python-WebUI](https://github.com/webui-dev/python-webui) |
-| TypeScript / JavaScript | ✔️ | [Deno-WebUI](https://github.com/webui-dev/deno-webui) |
-| Go | ✔️ | [Go-WebUI](https://github.com/webui-dev/go-webui) |
-| Rust | *Not Complete* | [Rust-WebUI](https://github.com/webui-dev/rust-webui) |
-| V | ✔️ | [V-WebUI](https://github.com/webui-dev/v-webui) |
-| Nim | ✔️ | [Nim-WebUI](https://github.com/webui-dev/nim-webui) |
-| Zig | *Not Complete* | [Zig-WebUI](https://github.com/webui-dev/zig-webui) |
+| Language                | Status         | Link                                                      |
+| ----------------------- | -------------- | --------------------------------------------------------- |
+| C/C++                   | ✔️              | [WebUI](https://github.com/webui-dev/webui)               |
+| Python                  | ✔️              | [Python-WebUI](https://github.com/webui-dev/python-webui) |
+| TypeScript / JavaScript | ✔️              | [Deno-WebUI](https://github.com/webui-dev/deno-webui)     |
+| Go                      | ✔️              | [Go-WebUI](https://github.com/webui-dev/go-webui)         |
+| Rust                    | _Not Complete_ | [Rust-WebUI](https://github.com/webui-dev/rust-webui)     |
+| V                       | ✔️              | [V-WebUI](https://github.com/webui-dev/v-webui)           |
+| Nim                     | ✔️              | [Nim-WebUI](https://github.com/webui-dev/nim-webui)       |
+| Zig                     | _Not Complete_ | [Zig-WebUI](https://github.com/webui-dev/zig-webui)       |
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ is written in Deno using WebUI as the GUI library.
 ```js
 import { webui } from "https://deno.land/x/webui@2.3.0/mod.ts";
 
-const my_window = webui.new_window();
-webui.show(my_window, "<html>Hello World</html>");
+const myWindow = webui.newWindow();
+webui.show(myWindow, "<html>Hello World</html>");
 await webui.wait();
 ```
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,23 @@
+//Preload lib files statically
+export {
+  //@ts-ignore ejm serve { b64: string }
+  default as webuid2Windows,
+} from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.dll" assert {
+  type: "json",
+};
+export {
+  //@ts-ignore ejm serve { b64: string }
+  default as webuid2Linux,
+} from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.so" assert {
+  type: "json",
+};
+export {
+  //@ts-ignore ejm serve { b64: string }
+  default as webuid2Darwin,
+} from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.dyn" assert {
+  type: "json",
+};
+
+export { exists, existsSync } from "https://deno.land/std@0.192.0/fs/mod.ts";
+export * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+export { default as osPaths } from "https://deno.land/x/os_paths@v7.4.0/src/mod.deno.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,19 +1,19 @@
 //Preload lib files statically
 export {
   //@ts-ignore ejm serve { b64: string }
-  default as webuid2Windows,
+  default as webui2Windows,
 } from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.dll" assert {
   type: "json",
 };
 export {
   //@ts-ignore ejm serve { b64: string }
-  default as webuid2Linux,
+  default as webui2Linux,
 } from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.so" assert {
   type: "json",
 };
 export {
   //@ts-ignore ejm serve { b64: string }
-  default as webuid2Darwin,
+  default as webui2Darwin,
 } from "https://ejm.sh/deno.land/x/webui@2.3.0/src/webui-2-x64.dyn" assert {
   type: "json",
 };

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,7 @@
-
 # WebUI Examples - Deno
 
-This is an example of how to use the WebUI dynamic library in Deno to create an HTML5 based user interface.
-
+This is an example of how to use the WebUI dynamic library in Deno to create an
+HTML5 based user interface.
 
 Tested using Deno v1.33.1.
 
@@ -10,9 +9,10 @@ Tested using Deno v1.33.1.
 
 This example shows how to use the WebUI Dynamic Library in Deno.
 
- 1. Download and [Install Deno](https://github.com/denoland/deno/releases) (*Or just copy deno binary file into this folder*)
- 2. Download WebUI pre-built Library (*[webui.me](https://webui.me/)*)
- 3. Run `deno run --allow-all --unstable hello_world.ts`
+1. Download and [Install Deno](https://github.com/denoland/deno/releases) (_Or
+   just copy deno binary file into this folder_)
+2. Download WebUI pre-built Library (_[webui.me](https://webui.me/)_)
+3. Run `deno run --allow-all --unstable hello_world.ts`
 
 Folder structure example:
 

--- a/examples/hello_world.ts
+++ b/examples/hello_world.ts
@@ -1,4 +1,3 @@
-
 // Run this script by:
 // deno run --allow-all --unstable hello_world.ts
 
@@ -49,8 +48,7 @@ const my_html = `
 </html>
 `;
 
-function calculate(e : webui.event) {
-
+function calculate(e: webui.Event) {
   // Create a JavaScript object
   const my_js = webui.js;
 
@@ -59,7 +57,7 @@ function calculate(e : webui.event) {
   // my_js.response_size = 64; // Set the response size in bytes
 
   // Call a js function
-  if(!webui.script(e.win, my_js, "return get_A()")) {
+  if (!webui.script(e.win, my_js, "return get_A()")) {
     // Error
     console.log("Error in the JavaScript: " + my_js.response);
     return;
@@ -69,7 +67,7 @@ function calculate(e : webui.event) {
   const A = my_js.response;
 
   // Call a js function
-  if(!webui.script(e.win, my_js, "return get_B();")) {
+  if (!webui.script(e.win, my_js, "return get_B();")) {
     // Error
     console.log("Error in the JavaScript: " + my_js.response);
     return;
@@ -79,18 +77,18 @@ function calculate(e : webui.event) {
   const B = my_js.response;
 
   // Calculate
-  const C : number = parseInt(A) + parseInt(B);
+  const C: number = parseInt(A) + parseInt(B);
 
   // Run js (Quick Way)
   webui.run(e.win, "set_result(" + C + ");");
 }
 
 // Create new window
-const my_window = webui.new_window();
+const my_window = webui.newWindow();
 
 // Bind
 webui.bind(my_window, "Calculate", calculate);
-webui.bind(my_window, "Exit", function(e : webui.event) {
+webui.bind(my_window, "Exit", function (e: webui.Event) {
   // Close all windows and exit
   webui.exit();
 });

--- a/examples/hello_world.ts
+++ b/examples/hello_world.ts
@@ -5,11 +5,11 @@
 import { webui } from "../mod.ts";
 
 // Optional - Set a custom library path:
-//  const lib_full_path = 'webui-2-x64.dll';
-//  console.log("Looking for the WebUI dynamic library at: " + lib_full_path);
-//  webui.set_lib_path(lib_full_path);
+//  const libFullPath = 'webui-2-x64.dll';
+//  console.log("Looking for the WebUI dynamic library at: " + libFullPath);
+//  webui.setLibPath(libFullPath);
 
-const my_html = `
+const myHtml = `
 <!DOCTYPE html>
 <html>
 	<head>
@@ -50,31 +50,31 @@ const my_html = `
 
 function calculate(e: webui.Event) {
   // Create a JavaScript object
-  const my_js = webui.js;
+  const myJs = webui.js;
 
   // Settings if needed
   // my_js.timeout = 30; // Set javascript execution timeout
   // my_js.response_size = 64; // Set the response size in bytes
 
   // Call a js function
-  if (!webui.script(e.win, my_js, "return get_A()")) {
+  if (!webui.script(e.win, myJs, "return get_A()")) {
     // Error
-    console.log("Error in the JavaScript: " + my_js.response);
+    console.log("Error in the JavaScript: " + myJs.response);
     return;
   }
 
   // Get A
-  const A = my_js.response;
+  const A = myJs.response;
 
   // Call a js function
-  if (!webui.script(e.win, my_js, "return get_B();")) {
+  if (!webui.script(e.win, myJs, "return get_B();")) {
     // Error
-    console.log("Error in the JavaScript: " + my_js.response);
+    console.log("Error in the JavaScript: " + myJs.response);
     return;
   }
 
   // Get B
-  const B = my_js.response;
+  const B = myJs.response;
 
   // Calculate
   const C: number = parseInt(A) + parseInt(B);
@@ -84,17 +84,17 @@ function calculate(e: webui.Event) {
 }
 
 // Create new window
-const my_window = webui.newWindow();
+const myWindow = await webui.newWindow();
 
 // Bind
-webui.bind(my_window, "Calculate", calculate);
-webui.bind(my_window, "Exit", function (_e: webui.Event) {
+webui.bind(myWindow, "Calculate", calculate);
+webui.bind(myWindow, "Exit", function (_e: webui.Event) {
   // Close all windows and exit
   webui.exit();
 });
 
 // Show the window
-webui.show(my_window, my_html); // Or webui.show(my_window, 'hello_world.html');
+webui.show(myWindow, myHtml); // Or webui.show(myWindow, 'hello_world.html');
 
 // Wait until all windows get closed
 await webui.wait();

--- a/examples/hello_world.ts
+++ b/examples/hello_world.ts
@@ -88,7 +88,7 @@ const my_window = webui.newWindow();
 
 // Bind
 webui.bind(my_window, "Calculate", calculate);
-webui.bind(my_window, "Exit", function (e: webui.Event) {
+webui.bind(my_window, "Exit", function (_e: webui.Event) {
   // Close all windows and exit
   webui.exit();
 });

--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,32 @@
+/**
+ * # WebUI
+ *
+ * > Use any web browser as GUI, with Deno in the backend and HTML5 in the
+ * > frontend, all in a lightweight Deno module.
+ *
+ * ## Features
+ *
+ * - Fully Independent (_No need for any third-party runtimes_)
+ * - Lightweight _~900 Kb_ for the whole package & Small memory footprint
+ * - Fast binary communication protocol between WebUI and the browser (_Instead of JSON_)
+ * - Multi-platform & Multi-Browser
+ * - Using private profile for safety
+ * - Original library written in Pure C
+ *
+ * ## Installation
+ * `import { webui } from "https://deno.land/x/webui/mod.ts";`
+ *
+ * ## Minimal Example
+ *
+ * ```ts
+ * import { webui } from "https://deno.land/x/webui/mod.ts";
+ *
+ * const myWindow = webui.newWindow();
+ * webui.show(myWindow, "<html>Hello World</html>");
+ * webui.wait();
+ * ```
+ *
+ * @module
+ * @license MIT
+ */
 export * as webui from "./src/webui.ts";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,9 +1,8 @@
-import { existsSync } from "https://deno.land/std@0.181.0/fs/mod.ts";
+import { existsSync } from "https://deno.land/std@0.192.0/fs/mod.ts";
 import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 
 // Check if a file exist
 function isFileExist(path: string): boolean {
-  // TODO: existsSync() is deprecated
   return existsSync(path);
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,4 @@
-import { webuid2Darwin, webuid2Linux, webuid2Windows } from "../deps.ts";
+import { webui2Darwin, webui2Linux, webui2Windows } from "../deps.ts";
 import { b64ToBuffer, writeLib } from "./utils.ts";
 export async function loadLib(libPath?: string) {
   // Determine the library name based
@@ -15,14 +15,14 @@ export async function loadLib(libPath?: string) {
   })();
 
   const libBuffer = (() => {
-    if (libPath !== undefined) {
+    if (libPath === undefined) {
       switch (Deno.build.os) {
         case "windows":
-          return b64ToBuffer(webuid2Windows.b64);
+          return b64ToBuffer(webui2Windows.b64);
         case "darwin":
-          return b64ToBuffer(webuid2Darwin.b64);
+          return b64ToBuffer(webui2Darwin.b64);
         default:
-          return b64ToBuffer(webuid2Linux.b64);
+          return b64ToBuffer(webui2Linux.b64);
       }
     }
     return new Uint8Array();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,127 @@
+import { existsSync } from "https://deno.land/std@0.181.0/fs/mod.ts";
+
+// Check if a file exist
+function isFileExist(path: string): boolean {
+  // TODO: existsSync() is deprecated
+  return existsSync(path);
+}
+
+// Get current folder path
+function getCurrentModulePath(): string {
+  const __dirname = new URL(".", import.meta.url).pathname;
+  let directory = String(__dirname);
+  if (Deno.build.os === "windows") {
+    // Remove '/'
+    let buf = directory.substring(1);
+    directory = buf;
+    // Replace '/' by '\'
+    buf = directory.replaceAll("/", osSep);
+    directory = buf;
+  }
+  return directory;
+}
+
+// Determine the library name based
+// on the current operating system
+let libName: string;
+let osSep: string;
+if (Deno.build.os === "windows") {
+  libName = "webui-2-x64.dll";
+  osSep = "\\";
+} else if (Deno.build.os === "linux") {
+  libName = "webui-2-x64.so";
+  osSep = "/";
+} else {
+  libName = "webui-2-x64.dyn";
+  osSep = "/";
+}
+
+export function loadLib(libPath?: string) {
+  // Check if the library file exist
+  if (!isFileExist(libPath ?? `./${libName}`)) {
+    const libPathCwd = getCurrentModulePath() + libName;
+    if (!isFileExist(libPathCwd)) {
+      console.log(
+        "WebUI Error: File not found (" +
+          libPath +
+          ") or (" +
+          libPathCwd +
+          ")",
+      );
+      Deno.exit(1);
+    }
+    libPath = libPathCwd;
+  }
+
+  return Deno.dlopen(
+    libPath!,
+    {
+      webui_wait: {
+        // void webui_wait(void)
+        parameters: [],
+        result: "void",
+        nonblocking: true,
+      },
+      webui_interface_is_app_running: {
+        // bool webui_interface_is_app_running(void)
+        parameters: [],
+        result: "i32",
+      },
+      webui_new_window: {
+        // size_t webui_new_window(void)
+        parameters: [],
+        result: "usize",
+      },
+      webui_show: {
+        // bool webui_show(size_t window, const char* content)
+        parameters: ["usize", "buffer"],
+        result: "i32",
+      },
+      webui_show_browser: {
+        // bool webui_show_browser(size_t window, const char* content, unsigned int browser)
+        parameters: ["usize", "buffer", "u32"],
+        result: "i32",
+      },
+      webui_interface_bind: {
+        // unsigned int webui_interface_bind(size_t window, const char* element, void (*func)(size_t, unsigned int, char*, char*, unsigned int))
+        parameters: ["usize", "buffer", "function"],
+        result: "u32",
+      },
+      webui_script: {
+        // bool webui_script(size_t window, const char* script, unsigned int timeout, char* buffer, size_t buffer_length)
+        parameters: ["usize", "buffer", "u32", "buffer", "i32"],
+        result: "i32",
+      },
+      webui_run: {
+        // bool webui_run(size_t window, const char* script)
+        parameters: ["usize", "buffer"],
+        result: "i32",
+      },
+      webui_interface_set_response: {
+        // void webui_interface_set_response(size_t window, unsigned int event_number, const char* response)
+        parameters: ["usize", "u32", "buffer"],
+        result: "void",
+      },
+      webui_exit: {
+        // void webui_exit(void)
+        parameters: [],
+        result: "void",
+      },
+      webui_is_shown: {
+        //bool webui_is_shown(size_t window)
+        parameters: ["usize"],
+        result: "bool",
+      },
+      webui_close: {
+        //void webui_close(size_t window)
+        parameters: ["usize"],
+        result: "void",
+      },
+      webui_set_multi_access: {
+        //void webui_set_multi_access(size_t window, bool status)
+        parameters: ["usize", "bool"],
+        result: "void",
+      },
+    } as const,
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,20 @@
+export type Usize = number | bigint;
+
+export type BindCallback<
+  T extends string | number | boolean | undefined | void,
+> = (
+  event: Event,
+) => T;
+
+export interface Js {
+  timeout: number;
+  bufferSize: number;
+  response: string;
+}
+
+export interface Event {
+  win: Usize;
+  eventType: number;
+  element: string;
+  data: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,5 @@ export function uint8arrayToString(value: ArrayBuffer): string {
 }
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export class WebUiError extends Error {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,24 @@
 import { exists, osPaths, path } from "../deps.ts";
 
+/**
+ * The function converts a base64 string to a Uint8Array buffer.
+ * @param {string} b64 - The parameter `b64` is a string that represents a base64 encoded value.
+ * @returns a Uint8Array, which is a typed array representing an array of 8-bit unsigned integers.
+ */
 export function b64ToBuffer(b64: string): Uint8Array {
   const byteArray = atob(b64).split("").map((c) => c.codePointAt(0) ?? 0);
   return new Uint8Array(byteArray);
 }
 
-// Get current folder path
-export function getCurrentModulePath(libPath: string): string {
-  const fsPath = path.fromFileUrl(import.meta.url);
-  const { dir } = path.parse(fsPath);
-  return path.join(dir, libPath);
-}
-
+/**
+ * The function `writeLib` writes a library file to a temporary directory and returns the path of the
+ * written file.
+ * @param {string} libName - The `libName` parameter is a string that represents the name of the
+ * library file that will be written.
+ * @param {Uint8Array} libBuffer - The `libBuffer` parameter is a `Uint8Array` that represents the
+ * binary data of the library file that needs to be written.
+ * @returns a promise that resolves to a string.
+ */
 export async function writeLib(
   libName: string,
   libBuffer: Uint8Array,
@@ -21,22 +28,33 @@ export async function writeLib(
     await Deno.writeFile(libPath, libBuffer);
   }
   if (!await exists(libPath)) {
-    throw new Error(`WebUI: Can't write ${libName} at ${libPath}`);
+    throw new WebUiError(`Can't write ${libName} at ${libPath}`);
   }
   return libPath;
 }
 
-// Convert String to C-String
+/**
+ * Convert a String to C-String.
+ * @param {string} value
+ * @returns a char[].
+ */
 export function stringToUint8array(value: string): Uint8Array {
   return new TextEncoder().encode(value + "\0");
 }
 
-// Convert C-String to String
-
+/**
+ * Convert C-String to String.
+ * @param {ArrayBuffer} value - an `ArrayBuffer` that contains a C-String.
+ * @returns a string.
+ */
 export function uint8arrayToString(value: ArrayBuffer): string {
   return new TextDecoder().decode(value);
 }
 
+/**
+ * Sleep for an amount of milliseconds.
+ * @param {number} ms
+ */
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export class WebUiError extends Error {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,40 @@
+import { exists, osPaths, path } from "../deps.ts";
+
+export function b64ToBuffer(b64: string): Uint8Array {
+  const byteArray = atob(b64).split("").map((c) => c.codePointAt(0) ?? 0);
+  return new Uint8Array(byteArray);
+}
+
+// Get current folder path
+export function getCurrentModulePath(libPath: string): string {
+  const fsPath = path.fromFileUrl(import.meta.url);
+  const { dir } = path.parse(fsPath);
+  return path.join(dir, libPath);
+}
+
+export async function writeLib(
+  libName: string,
+  libBuffer: Uint8Array,
+): Promise<string> {
+  const libPath = path.join(osPaths.temp(), libName);
+  if (!await exists(libPath)) {
+    await Deno.writeFile(libPath, libBuffer);
+  }
+  if (!await exists(libPath)) {
+    throw new Error(`WebUI: Can't write ${libName} at ${libPath}`);
+  }
+  return libPath;
+}
+
+// Convert String to C-String
+export function stringToUint8array(value: string): Uint8Array {
+  return new TextEncoder().encode(value + "\0");
+}
+
+// Convert C-String to String
+
+export function uint8arrayToString(value: ArrayBuffer): string {
+  return new TextDecoder().decode(value);
+}
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -32,6 +32,9 @@ export const browser = {
 };
 
 type Usize = number | bigint;
+type BindCallback<T extends string | number | boolean | undefined | void> = (
+  event: event,
+) => T;
 
 export interface event {
   win: Usize;
@@ -45,6 +48,12 @@ export const js = {
   BufferSize: 1024 * 8,
   response: "",
 };
+
+interface Js {
+  timeout: number;
+  BufferSize: number;
+  response: string;
+}
 
 // Determine the library name based
 // on the current operating system
@@ -225,7 +234,7 @@ export function exit() {
   webui_lib.symbols.webui_exit();
 }
 
-export function script(win: Usize, js, script: string): boolean {
+export function script(win: Usize, js: Js, script: string): boolean {
   // Response Buffer
   const size: number = js.BufferSize > 0 ? js.BufferSize : 1024 * 8;
   const buffer = new Uint8Array(size);
@@ -255,10 +264,10 @@ export function run(win: Usize, script: string): boolean {
   return Boolean(status);
 }
 
-export function bind(
+export function bind<T extends string | number | boolean | undefined | void>(
   win: Usize,
   element: string,
-  func: (event: event) => string,
+  func: BindCallback<T>,
 ) {
   const callbackResource = new Deno.UnsafeCallback(
     {

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -12,6 +12,8 @@
 
 import { loadLib } from "./lib.ts";
 import { BindCallback, Event, Js, Usize } from "./types.ts";
+import { existsSync } from "../deps.ts";
+import { sleep, stringToUint8array, uint8arrayToString } from "./utils.ts";
 
 export type { Event } from "./types.ts";
 
@@ -37,19 +39,12 @@ export const js = {
   response: "",
 };
 
-const webuiLib = loadLib();
-
-// Convert String to C-String
-function stringToUint8array(value: string): Uint8Array {
-  return new TextEncoder().encode(value + "\0");
-}
-
-// Convert C-String to String
-function uint8arrayToString(value: ArrayBuffer): string {
-  return new TextDecoder().decode(value);
-}
+const webuiLib = await loadLib();
 
 export function setLibPath(_path: string) {
+  if (!existsSync(_path)) {
+    throw new Error(`WebUI: File not found "${_path}"`);
+  }
   // libPath = path;
 }
 
@@ -176,7 +171,6 @@ export function bind<T extends string | number | boolean | undefined | void>(
 // TODO: We should use the Non-blocking FFI to call
 // `webui_lib.symbols.webui_wait()`. but it breaks
 // the Deno script main thread. Lets do it in another way for now.
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export async function wait() {
   while (true) {
     await sleep(10);

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -76,7 +76,7 @@ export function setLibPath(path: string) {
  * ```
  */
 export async function newWindow(): Promise<Usize> {
-  if (loaded) {
+  if (!loaded) {
     webuiLib = await loadLib(libPath);
     loaded = true;
   }

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -1,6 +1,6 @@
 /*
   WebUI Library 2.3.0
-  
+
   http://webui.me
   https://github.com/webui-dev/deno-webui
 
@@ -12,7 +12,7 @@
 
 import { existsSync } from "https://deno.land/std@0.181.0/fs/mod.ts";
 
-export const version = '2.3.0';
+export const version = "2.3.0";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -31,40 +31,38 @@ export const browser = {
   Yandex: 10, // 10. The Yandex Browser
 };
 
-type Usize = number | bigint
+type Usize = number | bigint;
 
 export interface event {
-  win: Usize,
-  event_type: number,
-  element: string,
-  data: string,
+  win: Usize;
+  event_type: number;
+  element: string;
+  data: string;
 }
 
 export const js = {
   timeout: 0,
-  BufferSize: (1024 * 8),
+  BufferSize: 1024 * 8,
   response: "",
-}
+};
 
 // Determine the library name based
 // on the current operating system
 let lib_name: string;
 let os_sep: string;
-if (Deno.build.os === 'windows') {
-  lib_name = 'webui-2-x64.dll';
-  os_sep = '\\';
-}
-else if (Deno.build.os === 'linux') {
-  lib_name = 'webui-2-x64.so';
-  os_sep = '/';
-}
-else {
-  lib_name = 'webui-2-x64.dyn';
-  os_sep = '/';
+if (Deno.build.os === "windows") {
+  lib_name = "webui-2-x64.dll";
+  os_sep = "\\";
+} else if (Deno.build.os === "linux") {
+  lib_name = "webui-2-x64.so";
+  os_sep = "/";
+} else {
+  lib_name = "webui-2-x64.dyn";
+  os_sep = "/";
 }
 
 // Full path to the library name
-let lib_path = './' + lib_name;
+let lib_path = "./" + lib_name;
 
 // Check if a file exist
 function is_file_exist(path: string): boolean {
@@ -74,19 +72,19 @@ function is_file_exist(path: string): boolean {
 
 // Convert String to C-String
 function string_to_uint8array(value: string): Uint8Array {
-  return encoder.encode(value + '\0');
+  return encoder.encode(value + "\0");
 }
 
 // Get current folder path
 function get_current_module_path(): string {
-  const __dirname = new URL('.', import.meta.url).pathname;
+  const __dirname = new URL(".", import.meta.url).pathname;
   let directory = String(__dirname);
-  if (Deno.build.os === 'windows') {
+  if (Deno.build.os === "windows") {
     // Remove '/'
     let buf = directory.substring(1);
     directory = buf;
     // Replace '/' by '\'
-    buf = directory.replaceAll('/', os_sep);
+    buf = directory.replaceAll("/", os_sep);
     directory = buf;
   }
   return directory;
@@ -100,10 +98,16 @@ function uint8array_to_string(value: ArrayBuffer): string {
 // Load the library
 
 // Check if the library file exist
-if(!is_file_exist(lib_path)) {
+if (!is_file_exist(lib_path)) {
   const lib_path_cwd = get_current_module_path() + lib_name;
-  if(!is_file_exist(lib_path_cwd)) {
-    console.log('WebUI Error: File not found (' + lib_path + ') or (' + lib_path_cwd + ')');
+  if (!is_file_exist(lib_path_cwd)) {
+    console.log(
+      "WebUI Error: File not found (" +
+        lib_path +
+        ") or (" +
+        lib_path_cwd +
+        ")",
+    );
     Deno.exit(1);
   }
   lib_path = lib_path_cwd;
@@ -117,80 +121,104 @@ const webui_lib = Deno.dlopen(
     webui_wait: {
       // void webui_wait(void)
       parameters: [],
-      result: 'void',
+      result: "void",
       nonblocking: true,
     },
     webui_interface_is_app_running: {
       // bool webui_interface_is_app_running(void)
       parameters: [],
-      result: 'i32',
-      nonblocking: false,
+      result: "i32",
     },
     webui_new_window: {
       // size_t webui_new_window(void)
       parameters: [],
-      result: 'usize',
-      nonblocking: false,
+      result: "usize",
     },
     webui_show: {
       // bool webui_show(size_t window, const char* content)
-      parameters: ['usize', 'buffer'],
-      result: 'i32',
-      nonblocking: false,
+      parameters: ["usize", "buffer"],
+      result: "i32",
     },
     webui_show_browser: {
       // bool webui_show_browser(size_t window, const char* content, unsigned int browser)
-      parameters: ['usize', 'buffer', 'u32'],
-      result: 'i32',
-      nonblocking: false,
+      parameters: ["usize", "buffer", "u32"],
+      result: "i32",
     },
     webui_interface_bind: {
       // unsigned int webui_interface_bind(size_t window, const char* element, void (*func)(size_t, unsigned int, char*, char*, unsigned int))
-      parameters: ['usize', 'buffer', 'function'],
-      result: 'u32',
-      nonblocking: false,
+      parameters: ["usize", "buffer", "function"],
+      result: "u32",
     },
     webui_script: {
       // bool webui_script(size_t window, const char* script, unsigned int timeout, char* buffer, size_t buffer_length)
-      parameters: ['usize', 'buffer', 'u32', 'buffer', 'i32'],
-      result: 'i32',
-      nonblocking: false,
+      parameters: ["usize", "buffer", "u32", "buffer", "i32"],
+      result: "i32",
     },
     webui_run: {
       // bool webui_run(size_t window, const char* script)
-      parameters: ['usize', 'buffer'],
-      result: 'i32',
-      nonblocking: false,
+      parameters: ["usize", "buffer"],
+      result: "i32",
     },
     webui_interface_set_response: {
       // void webui_interface_set_response(size_t window, unsigned int event_number, const char* response)
-      parameters: ['usize', 'u32', 'buffer'],
-      result: 'void',
-      nonblocking: false,
+      parameters: ["usize", "u32", "buffer"],
+      result: "void",
     },
     webui_exit: {
       // void webui_exit(void)
       parameters: [],
-      result: 'void',
-      nonblocking: false,
-    }
+      result: "void",
+    },
+    webui_is_shown: {
+      //bool webui_is_shown(size_t window)
+      parameters: ["usize"],
+      result: "bool",
+    },
+    webui_close: {
+      //void webui_close(size_t window)
+      parameters: ["usize"],
+      result: "void",
+    },
+    webui_set_multi_access: {
+      //void webui_set_multi_access(size_t window, bool status)
+      parameters: ["usize", "bool"],
+      result: "void",
+    },
   } as const,
 );
 
 export function set_lib_path(path: string) {
-	lib_path = path;
+  lib_path = path;
 }
 
 export function new_window(): Usize {
-	return webui_lib.symbols.webui_new_window();
+  return webui_lib.symbols.webui_new_window();
 }
 
 export function show(win: Usize, content: string): number {
   return webui_lib.symbols.webui_show(win, string_to_uint8array(content));
 }
 
-export function show_browser(win: Usize, content: string, browser: number): number {
-  return webui_lib.symbols.webui_show_browser(win, string_to_uint8array(content), browser);
+export function show_browser(
+  win: Usize,
+  content: string,
+  browser: number,
+): number {
+  return webui_lib.symbols.webui_show_browser(
+    win,
+    string_to_uint8array(content),
+    browser,
+  );
+}
+
+export function webui_is_shown(win: Usize) {
+  return webui_lib.symbols.webui_is_shown(win);
+}
+export function webui_close(win: Usize) {
+  return webui_lib.symbols.webui_close(win);
+}
+export function webui_set_multi_access(win: Usize, status: boolean) {
+  return webui_lib.symbols.webui_set_multi_access(win, status);
 }
 
 export function exit() {
@@ -199,11 +227,17 @@ export function exit() {
 
 export function script(win: Usize, js, script: string): boolean {
   // Response Buffer
-  const size: number = (js.BufferSize > 0 ? js.BufferSize: (1024 * 8));
+  const size: number = js.BufferSize > 0 ? js.BufferSize : 1024 * 8;
   const buffer = new Uint8Array(size);
 
   // Execute the script
-  const status = webui_lib.symbols.webui_script(win, string_to_uint8array(script), js.timeout, buffer, size);
+  const status = webui_lib.symbols.webui_script(
+    win,
+    string_to_uint8array(script),
+    js.timeout,
+    buffer,
+    size,
+  );
 
   // Update
   js.response = String(uint8array_to_string(buffer));
@@ -213,31 +247,41 @@ export function script(win: Usize, js, script: string): boolean {
 
 export function run(win: Usize, script: string): boolean {
   // Execute the script
-  const status = webui_lib.symbols.webui_run(win, string_to_uint8array(script));
+  const status = webui_lib.symbols.webui_run(
+    win,
+    string_to_uint8array(script),
+  );
 
   return Boolean(status);
 }
 
-export function bind(win: Usize, element: string, func: (event: event) => string) {
+export function bind(
+  win: Usize,
+  element: string,
+  func: (event: event) => string,
+) {
   const callbackResource = new Deno.UnsafeCallback(
     {
       // unsigned int webui_interface_bind(..., void (*func)(size_t, unsigned int, char*, char*, unsigned int))
-      parameters: ['usize', 'u32', 'pointer', 'pointer', 'u32'],
-      result: 'void',
+      parameters: ["usize", "u32", "pointer", "pointer", "u32"],
+      result: "void",
     } as const,
     (
       param_window: Usize,
       param_event_type: number,
       param_element: Deno.PointerValue,
       param_data: Deno.PointerValue,
-      param_event_number: number
+      param_event_number: number,
     ) => {
-
       // Create elements
       const win = param_window;
       const event_type = Math.trunc(param_event_type);
-      const element = (param_element != null ? (new Deno.UnsafePointerView(param_element).getCString()) : "");
-      const data = (param_data != null ? (new Deno.UnsafePointerView(param_data).getCString()) : "");
+      const element = param_element != null
+        ? new Deno.UnsafePointerView(param_element).getCString()
+        : "";
+      const data = param_data != null
+        ? new Deno.UnsafePointerView(param_data).getCString()
+        : "";
       const event_number = Math.trunc(param_event_number);
 
       // Create struct
@@ -252,21 +296,28 @@ export function bind(win: Usize, element: string, func: (event: event) => string
       const result = String(func(e));
 
       // Send back the response
-      webui_lib.symbols.webui_interface_set_response(win, event_number, string_to_uint8array(result));
+      webui_lib.symbols.webui_interface_set_response(
+        win,
+        event_number,
+        string_to_uint8array(result),
+      );
     },
   );
 
-  webui_lib.symbols.webui_interface_bind(win, string_to_uint8array(element), callbackResource.pointer);
+  webui_lib.symbols.webui_interface_bind(
+    win,
+    string_to_uint8array(element),
+    callbackResource.pointer,
+  );
 }
 
-// TODO: We should use the Non-blocking FFI to call 
+// TODO: We should use the Non-blocking FFI to call
 // `webui_lib.symbols.webui_wait()`. but it breaks
 // the Deno script main thread. Lets do it in another way for now.
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export async function wait() {
-  while(true) {
+  while (true) {
     await sleep(10);
-    if(!webui_lib.symbols.webui_interface_is_app_running())
-      break;
+    if (!webui_lib.symbols.webui_interface_is_app_running()) break;
   }
 }

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -39,16 +39,22 @@ export const js = {
   response: "",
 };
 
-const webuiLib = await loadLib();
+let webuiLib: Awaited<ReturnType<typeof loadLib>>;
+let loaded = false;
+let libPath: string | undefined = undefined;
 
-export function setLibPath(_path: string) {
-  if (!existsSync(_path)) {
-    throw new Error(`WebUI: File not found "${_path}"`);
+export function setLibPath(path: string) {
+  if (!existsSync(path)) {
+    throw new Error(`WebUI: File not found "${path}"`);
   }
-  // libPath = path;
+  libPath = path;
 }
 
-export function newWindow(): Usize {
+export async function newWindow(): Promise<Usize> {
+  if (loaded) {
+    webuiLib = await loadLib(libPath);
+    loaded = true;
+  }
   return webuiLib.symbols.webui_new_window();
 }
 

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -33,59 +33,59 @@ export const browser = {
 
 type Usize = number | bigint;
 type BindCallback<T extends string | number | boolean | undefined | void> = (
-  event: event,
+  event: Event,
 ) => T;
 
-export interface event {
+export interface Event {
   win: Usize;
-  event_type: number;
+  eventType: number;
   element: string;
   data: string;
 }
 
 export const js = {
   timeout: 0,
-  BufferSize: 1024 * 8,
+  bufferSize: 1024 * 8,
   response: "",
 };
 
 interface Js {
   timeout: number;
-  BufferSize: number;
+  bufferSize: number;
   response: string;
 }
 
 // Determine the library name based
 // on the current operating system
-let lib_name: string;
-let os_sep: string;
+let libName: string;
+let osSep: string;
 if (Deno.build.os === "windows") {
-  lib_name = "webui-2-x64.dll";
-  os_sep = "\\";
+  libName = "webui-2-x64.dll";
+  osSep = "\\";
 } else if (Deno.build.os === "linux") {
-  lib_name = "webui-2-x64.so";
-  os_sep = "/";
+  libName = "webui-2-x64.so";
+  osSep = "/";
 } else {
-  lib_name = "webui-2-x64.dyn";
-  os_sep = "/";
+  libName = "webui-2-x64.dyn";
+  osSep = "/";
 }
 
 // Full path to the library name
-let lib_path = "./" + lib_name;
+let libPath = "./" + libName;
 
 // Check if a file exist
-function is_file_exist(path: string): boolean {
+function isFileExist(path: string): boolean {
   // TODO: existsSync() is deprecated
   return existsSync(path);
 }
 
 // Convert String to C-String
-function string_to_uint8array(value: string): Uint8Array {
+function stringToUint8array(value: string): Uint8Array {
   return encoder.encode(value + "\0");
 }
 
 // Get current folder path
-function get_current_module_path(): string {
+function getCurrentModulePath(): string {
   const __dirname = new URL(".", import.meta.url).pathname;
   let directory = String(__dirname);
   if (Deno.build.os === "windows") {
@@ -93,39 +93,39 @@ function get_current_module_path(): string {
     let buf = directory.substring(1);
     directory = buf;
     // Replace '/' by '\'
-    buf = directory.replaceAll("/", os_sep);
+    buf = directory.replaceAll("/", osSep);
     directory = buf;
   }
   return directory;
 }
 
 // Convert C-String to String
-function uint8array_to_string(value: ArrayBuffer): string {
+function uint8arrayToString(value: ArrayBuffer): string {
   return decoder.decode(value);
 }
 
 // Load the library
 
 // Check if the library file exist
-if (!is_file_exist(lib_path)) {
-  const lib_path_cwd = get_current_module_path() + lib_name;
-  if (!is_file_exist(lib_path_cwd)) {
+if (!isFileExist(libPath)) {
+  const libPathCwd = getCurrentModulePath() + libName;
+  if (!isFileExist(libPathCwd)) {
     console.log(
       "WebUI Error: File not found (" +
-        lib_path +
+        libPath +
         ") or (" +
-        lib_path_cwd +
+        libPathCwd +
         ")",
     );
     Deno.exit(1);
   }
-  lib_path = lib_path_cwd;
+  libPath = libPathCwd;
 }
 
 // Load the library
 // FFI
-const webui_lib = Deno.dlopen(
-  lib_path,
+const webuiLib = Deno.dlopen(
+  libPath,
   {
     webui_wait: {
       // void webui_wait(void)
@@ -196,69 +196,69 @@ const webui_lib = Deno.dlopen(
   } as const,
 );
 
-export function set_lib_path(path: string) {
-  lib_path = path;
+export function setLibPath(path: string) {
+  libPath = path;
 }
 
-export function new_window(): Usize {
-  return webui_lib.symbols.webui_new_window();
+export function newWindow(): Usize {
+  return webuiLib.symbols.webui_new_window();
 }
 
 export function show(win: Usize, content: string): number {
-  return webui_lib.symbols.webui_show(win, string_to_uint8array(content));
+  return webuiLib.symbols.webui_show(win, stringToUint8array(content));
 }
 
-export function show_browser(
+export function showBrowser(
   win: Usize,
   content: string,
   browser: number,
 ): number {
-  return webui_lib.symbols.webui_show_browser(
+  return webuiLib.symbols.webui_show_browser(
     win,
-    string_to_uint8array(content),
+    stringToUint8array(content),
     browser,
   );
 }
 
-export function webui_is_shown(win: Usize) {
-  return webui_lib.symbols.webui_is_shown(win);
+export function isShown(win: Usize) {
+  return webuiLib.symbols.webui_is_shown(win);
 }
-export function webui_close(win: Usize) {
-  return webui_lib.symbols.webui_close(win);
+export function close(win: Usize) {
+  return webuiLib.symbols.webui_close(win);
 }
-export function webui_set_multi_access(win: Usize, status: boolean) {
-  return webui_lib.symbols.webui_set_multi_access(win, status);
+export function setMultiAccess(win: Usize, status: boolean) {
+  return webuiLib.symbols.webui_set_multi_access(win, status);
 }
 
 export function exit() {
-  webui_lib.symbols.webui_exit();
+  webuiLib.symbols.webui_exit();
 }
 
 export function script(win: Usize, js: Js, script: string): boolean {
   // Response Buffer
-  const size: number = js.BufferSize > 0 ? js.BufferSize : 1024 * 8;
+  const size: number = js.bufferSize > 0 ? js.bufferSize : 1024 * 8;
   const buffer = new Uint8Array(size);
 
   // Execute the script
-  const status = webui_lib.symbols.webui_script(
+  const status = webuiLib.symbols.webui_script(
     win,
-    string_to_uint8array(script),
+    stringToUint8array(script),
     js.timeout,
     buffer,
     size,
   );
 
   // Update
-  js.response = String(uint8array_to_string(buffer));
+  js.response = String(uint8arrayToString(buffer));
 
   return Boolean(status);
 }
 
 export function run(win: Usize, script: string): boolean {
   // Execute the script
-  const status = webui_lib.symbols.webui_run(
+  const status = webuiLib.symbols.webui_run(
     win,
-    string_to_uint8array(script),
+    stringToUint8array(script),
   );
 
   return Boolean(status);
@@ -294,9 +294,9 @@ export function bind<T extends string | number | boolean | undefined | void>(
       const event_number = Math.trunc(param_event_number);
 
       // Create struct
-      const e: event = {
+      const e: Event = {
         win: win,
-        event_type: event_type,
+        eventType: event_type,
         element: element,
         data: data,
       };
@@ -305,17 +305,17 @@ export function bind<T extends string | number | boolean | undefined | void>(
       const result = String(func(e));
 
       // Send back the response
-      webui_lib.symbols.webui_interface_set_response(
+      webuiLib.symbols.webui_interface_set_response(
         win,
         event_number,
-        string_to_uint8array(result),
+        stringToUint8array(result),
       );
     },
   );
 
-  webui_lib.symbols.webui_interface_bind(
+  webuiLib.symbols.webui_interface_bind(
     win,
-    string_to_uint8array(element),
+    stringToUint8array(element),
     callbackResource.pointer,
   );
 }
@@ -327,6 +327,6 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export async function wait() {
   while (true) {
     await sleep(10);
-    if (!webui_lib.symbols.webui_interface_is_app_running()) break;
+    if (!webuiLib.symbols.webui_interface_is_app_running()) break;
   }
 }


### PR DESCRIPTION
# Motivation
The module follow style convention of C instead of Deno/Typescript, there is also some type errors to fix and refactor to do.

# Changes
- Change style conventions.
- Cache webui-2 lib with static import via ejm.sh. Lib is cached before runtime and can be replace by local one if needed.
- Refactor some parts.
- Add symbols to ffi.
- Add JsDoc to all exports.
- Fix deprecated.
- Split code to improve readability and maintainability.

I don't know if the project follow semantic versionning so I don't update version.