### PR TITLE
setFileHandler to write buffer length

### DIFF
--- a/src/webui.ts
+++ b/src/webui.ts
@@ -409,11 +409,12 @@ export class WebUI {
     // const void* (*handler)(const char *filename, int *length)
     const cb = new Deno.UnsafeCallback(
       {
-        parameters: ["buffer"],
+        parameters: ["buffer", "pointer"],
         result: "pointer",
       },
       (
         pointerUrl: Deno.PointerValue,
+        pointerLength: Deno.PointerValue
       ) => {
         const url = pointerUrl !== null
           ? new Deno.UnsafePointerView(pointerUrl).getCString()
@@ -423,6 +424,10 @@ export class WebUI {
         const buffer = typeof response === "string"
           ? toCString(response)
           : response;
+
+        const lengthView = new Int32Array(Deno.UnsafePointerView.getArrayBuffer(pointerLength, 4));
+        lengthView[0] = buffer.length;
+
         return Deno.UnsafePointer.of(buffer);
       },
     );
@@ -432,7 +437,7 @@ export class WebUI {
       cb.pointer,
     );
   }
-
+  
   /**
    * Waits until all opened windows are closed for preventing exiting the main thread.
    * @exemple


### PR DESCRIPTION
Otherwise, binary files were sent with wrong headers

strlen works here as fallback for text files, but not binary files, those contain null symbols which are treated as end of string by strlen

https://github.com/webui-dev/webui/blob/2ca3b793c4fde6d9328937298dec30190a02afaa/src/webui.c#L2288

particularly, attempting to read .woff fonts were resulting in passing header "Content-Length: 4" resulting in browser error

"OTS parsing error: Size of decompressed WOFF 2.0 is less than compressed size"

