### PR TITLE
replace deprecated deno run --unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ await WebUI.wait();
 ```
 
 ```sh
-deno run --allow-all --unstable minimal.ts
+deno run --allow-all --unstable-ffi --allow-ffi minimal.ts
 ```
 
 [More examples](https://github.com/webui-dev/deno-webui/tree/main/examples)


### PR DESCRIPTION
Suggest to change README Installation instructions from:

`deno run --allow-all --unstable minimal.ts`

to 

`deno run --allow-all --unstable-ffi --allow-ffi minimal.ts`

`--unstable` will build the "minimal" app but it is deprecated and fails to build other apps.